### PR TITLE
Update the github links to swagger-ui repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN rm -f /etc/nginx/sites-enabled/default
 
 RUN echo 'daemon off;' >> /etc/nginx/nginx.conf
 
-ADD https://github.com/wordnik/swagger-ui/archive/master.zip /swagger/
+ADD https://github.com/swagger-api/swagger-ui/archive/master.zip /swagger/
 
 WORKDIR /swagger
 RUN unzip master.zip 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ...in a docker container
 
-[Swagger UI](https://github.com/wordnik/swagger-ui) ([Demo](http://petstore.swagger.wordnik.com/))
+[Swagger UI](https://github.com/swagger-api/swagger-ui) ([Demo](http://petstore.swagger.wordnik.com/))
 
 # Run
 


### PR DESCRIPTION
Present links to swagger-ui Github repo are old and redirect to [here](https://github.com/swagger-api/swagger-ui).

This PR updates all instances of old link with new link.
